### PR TITLE
[#8] 🧬 feat: add basic architecture of datatypes with CounterCrdt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,10 +116,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "ctor"
@@ -129,6 +173,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -421,6 +486,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +771,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_threads"
@@ -1170,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1200,6 +1298,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1263,7 +1367,9 @@ name = "syncyam"
 version = "0.1.0"
 dependencies = [
  "awaitility",
+ "chrono",
  "ctor",
+ "derive_more",
  "itoa",
  "libc",
  "nanoid",
@@ -1273,6 +1379,8 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "rstest",
+ "serde",
+ "serde_json",
  "time",
  "tokio",
  "tracing",
@@ -1615,6 +1723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1887,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,7 @@ tracing = [
 ]
 
 [dependencies]
-tracing = "^0.1.41"
-nanoid = "^0.4.0"
-tokio = { version = "^1.47.1", features = ["full"] }
-parking_lot = "^0.12.4"
-time = { version = "^0.3", features = ["formatting", "local-offset", "macros"]}
-
+# optional
 libc = { version = "^0.2.172", optional = true }
 once_cell = { version = "^1.21.3", optional = true }
 tracing-subscriber = { version = "^0.3.19", features = ["json", "fmt", "env-filter"], optional = true }
@@ -33,7 +28,17 @@ opentelemetry_sdk = { version = "^0.30.0", optional = true }
 opentelemetry-otlp = { version = "^0.30.0", features = ["grpc-tonic"], optional = true }
 tracing-opentelemetry = { version = "^0.31.0", optional = true }
 ctor = { version = "^0.5.0", optional = true }
-itoa = "1.0.15"
+
+tracing = "^0.1.41"
+nanoid = "^0.4.0"
+tokio = { version = "^1.47.1", features = ["full"] }
+parking_lot = "^0.12.4"
+time = { version = "^0.3", features = ["formatting", "local-offset", "macros"]}
+itoa = "^1.0.15"
+derive_more = { version = "^2.0.1", features = ["display", "debug"] }
+chrono = "0.4.41"
+serde = { version = "^1.0.219", features = ["derive", "rc"] }
+serde_json = "^1.0.143"
 
 [dev-dependencies]
 rstest = "^0.26.1"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 
 .PHONY: tarpaulin
 tarpaulin:
-	cargo tarpaulin -o html --all-features --engine llvm --output-dir ./coverage
+	SYNCYAM_RS_OTEL_ENABLED=true cargo tarpaulin -o html --all-features --engine llvm --output-dir ./coverage
 	open coverage/tarpaulin-report.html
 
 .PHONY: enable-jeager
@@ -23,3 +23,6 @@ enable-jeager:
       -p 5778:5778 \
       -p 9411:9411 \
       cr.jaegertracing.io/jaegertracing/jaeger:latest
+
+doc:
+	cargo doc --open

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,17 @@ install:
 
 .PHONY: lint
 lint:
-	cargo +nightly fmt --check
+	cargo +nightly fmt --all --check
 	cargo check --all-features --tests
-	cargo clippy --tests --all-features  -- -D warnings
+	cargo clippy --workspace --all-targets --tests --all-features -- -D warnings
 
 .PHONY: tarpaulin
 tarpaulin:
 	SYNCYAM_RS_OTEL_ENABLED=true cargo tarpaulin -o html --all-features --engine llvm --output-dir ./coverage
 	open coverage/tarpaulin-report.html
 
-.PHONY: enable-jeager
-enable-jeager:
+.PHONY: enable-jaeger
+enable-jaeger:
 	export SYNCYAM_RS_OTEL_ENABLED=true
 	docker run --rm -d --name jaeger \
       -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 \
@@ -24,5 +24,6 @@ enable-jeager:
       -p 9411:9411 \
       cr.jaegertracing.io/jaegertracing/jaeger:latest
 
+.PHONY: doc
 doc:
 	cargo doc --open

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use crate::{
+    DataType, DatatypeState,
+    datatypes::{datatype::DatatypeBlanket, thread_safe::ThreadSafeDatatype},
+    operations::Operation,
+};
+
+/// Counter is a conflict-free datatype that can be increased.
+pub struct Counter {
+    datatype: Arc<ThreadSafeDatatype>,
+}
+
+impl Counter {
+    pub(crate) fn new(key: String, state: DatatypeState) -> Self {
+        Counter {
+            datatype: Arc::new(ThreadSafeDatatype::new(&key, DataType::Counter, state)),
+        }
+    }
+
+    pub fn increase_by(&self, delta: i64) -> i64 {
+        let _op = Operation::new_counter_increase(delta);
+        0
+    }
+
+    pub fn increase(&self) -> i64 {
+        self.increase_by(1)
+    }
+}
+
+impl DatatypeBlanket for Counter {
+    fn get_core(&self) -> &ThreadSafeDatatype {
+        self.datatype.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests_counter {
+    use crate::{
+        DataType,
+        datatypes::{counter::Counter, datatype::Datatype},
+    };
+
+    #[test]
+    fn can_assert_send_and_sync_traits() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Counter>();
+    }
+
+    #[test]
+    fn can_call_public_blanket_trait_methods() {
+        let counter = Counter::new(module_path!().to_string(), Default::default());
+        assert_eq!(counter.get_type(), DataType::Counter);
+        assert_eq!(counter.get_key(), module_path!().to_string());
+        assert_eq!(counter.get_state(), Default::default());
+    }
+}

--- a/src/datatypes/crdts/counter_crdt.rs
+++ b/src/datatypes/crdts/counter_crdt.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Debug)]
+pub struct CounterCrdt {
+    value: i64,
+}
+
+impl CounterCrdt {
+    pub fn new() -> Self {
+        Self { value: 0 }
+    }
+
+    pub fn increase_by(&mut self, value: i64) -> i64 {
+        self.value += value;
+        self.value
+    }
+
+    pub fn value(&self) -> i64 {
+        self.value
+    }
+}
+
+impl Serialize for CounterCrdt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_i64(self.value)
+    }
+}
+
+impl<'de> Deserialize<'de> for CounterCrdt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = i64::deserialize(deserializer)?;
+        Ok(Self { value })
+    }
+}
+
+#[cfg(test)]
+mod tests_counter_crdt {
+    use tracing::info;
+
+    use crate::datatypes::crdts::counter_crdt::CounterCrdt;
+
+    #[test]
+    fn can_new_and_increase_counter() {
+        let mut counter = CounterCrdt::new();
+        counter.increase_by(1);
+        counter.increase_by(-2);
+        assert_eq!(counter.value(), -1);
+    }
+
+    #[test]
+    fn can_serialize_and_deserialize_counter_crdt() {
+        let mut counter = CounterCrdt::new();
+        counter.increase_by(123);
+
+        let serialized = serde_json::to_string(&counter).unwrap();
+        info!("serialized counter: {serialized}");
+        assert_eq!(serialized, "123");
+
+        let deserialized: CounterCrdt = serde_json::from_str::<CounterCrdt>(&serialized).unwrap();
+        assert_eq!(deserialized.value(), counter.value());
+    }
+}

--- a/src/datatypes/crdts/mod.rs
+++ b/src/datatypes/crdts/mod.rs
@@ -1,0 +1,19 @@
+use crate::{DataType, datatypes::crdts::counter_crdt::CounterCrdt};
+
+#[allow(dead_code)]
+pub mod counter_crdt;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum Crdt {
+    Counter(CounterCrdt),
+}
+
+impl Crdt {
+    pub fn new(r#type: DataType) -> Self {
+        match r#type {
+            DataType::Counter => Crdt::Counter(CounterCrdt::new()),
+            _ => unreachable!("invalid type"),
+        }
+    }
+}

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -1,0 +1,45 @@
+use crate::{DataType, DatatypeState, datatypes::thread_safe::ThreadSafeDatatype};
+
+pub trait Datatype {
+    fn get_key(&self) -> &str;
+    fn get_type(&self) -> DataType;
+    fn get_state(&self) -> DatatypeState;
+}
+
+pub trait DatatypeBlanket {
+    fn get_core(&self) -> &ThreadSafeDatatype;
+}
+
+impl<T> Datatype for T
+where
+    T: DatatypeBlanket,
+{
+    fn get_key(&self) -> &str {
+        self.get_core().get_key()
+    }
+
+    fn get_type(&self) -> DataType {
+        self.get_core().get_type()
+    }
+
+    fn get_state(&self) -> DatatypeState {
+        self.get_core().get_state()
+    }
+}
+
+#[cfg(test)]
+mod tests_datatype_trait {
+    use crate::{
+        DataType, DatatypeState,
+        datatypes::{datatype::Datatype, thread_safe::ThreadSafeDatatype},
+    };
+
+    #[test]
+    fn can_call_datatype_trait_functions() {
+        let key = module_path!();
+        let data = ThreadSafeDatatype::new(key, DataType::Counter, DatatypeState::DueToCreate);
+        assert_eq!(data.get_key(), key);
+        assert_eq!(data.get_type(), DataType::Counter);
+        assert_eq!(data.get_state(), DatatypeState::DueToCreate);
+    }
+}

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -1,3 +1,6 @@
-mod datatype;
+#[allow(dead_code)]
+pub mod counter;
+mod crdts;
+pub mod datatype;
 mod mutable;
 mod thread_safe;

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -1,0 +1,3 @@
+mod datatype;
+mod mutable;
+mod thread_safe;

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -1,5 +1,7 @@
-use crate::DatatypeState;
+use crate::{DatatypeState, datatypes::crdts::Crdt};
 
 pub struct MutableDatatype {
     pub state: DatatypeState,
+    #[allow(dead_code)]
+    pub crdt: Crdt,
 }

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -1,0 +1,5 @@
+use crate::DatatypeState;
+
+pub struct MutableDatatype {
+    pub state: DatatypeState,
+}

--- a/src/datatypes/thread_safe.rs
+++ b/src/datatypes/thread_safe.rs
@@ -1,0 +1,41 @@
+use parking_lot::RwLock;
+
+use crate::{
+    DataType, DatatypeState,
+    datatypes::{datatype::Datatype, mutable::MutableDatatype},
+};
+
+struct Attributes {
+    key: String,
+    r#type: DataType,
+}
+
+pub struct ThreadSafeDatatype {
+    attr: Attributes,
+    mutable: RwLock<MutableDatatype>,
+}
+
+impl Datatype for ThreadSafeDatatype {
+    fn get_key(&self) -> &str {
+        self.attr.key.as_ref()
+    }
+
+    fn get_type(&self) -> DataType {
+        self.attr.r#type
+    }
+
+    fn get_state(&self) -> DatatypeState {
+        self.mutable.read().state
+    }
+}
+
+impl ThreadSafeDatatype {
+    pub fn new(key: &str, r#type: DataType, state: DatatypeState) -> Self {
+        let attr = Attributes {
+            key: key.to_owned(),
+            r#type,
+        };
+        let mutable = RwLock::new(MutableDatatype { state });
+        Self { attr, mutable }
+    }
+}

--- a/src/datatypes/thread_safe.rs
+++ b/src/datatypes/thread_safe.rs
@@ -2,7 +2,7 @@ use parking_lot::RwLock;
 
 use crate::{
     DataType, DatatypeState,
-    datatypes::{datatype::Datatype, mutable::MutableDatatype},
+    datatypes::{crdts::Crdt, datatype::Datatype, mutable::MutableDatatype},
 };
 
 struct Attributes {
@@ -35,7 +35,10 @@ impl ThreadSafeDatatype {
             key: key.to_owned(),
             r#type,
         };
-        let mutable = RwLock::new(MutableDatatype { state });
+        let mutable = RwLock::new(MutableDatatype {
+            state,
+            crdt: Crdt::new(r#type),
+        });
         Self { attr, mutable }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
-pub use crate::types::datatype::{DataType, DatatypeState};
-
+pub use crate::{
+    datatypes::{counter::Counter, datatype::Datatype},
+    types::datatype::{DataType, DatatypeState},
+};
 #[allow(dead_code)]
 mod constants;
-mod datatypes;
+pub(crate) mod datatypes;
 pub(crate) mod observability;
+pub(crate) mod operations;
 pub(crate) mod types;
 pub(crate) mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
+pub use crate::types::datatype::{DataType, DatatypeState};
+
 #[allow(dead_code)]
 mod constants;
+mod datatypes;
 pub(crate) mod observability;
 pub(crate) mod types;
 pub(crate) mod utils;

--- a/src/observability/tracing_for_test.rs
+++ b/src/observability/tracing_for_test.rs
@@ -33,7 +33,6 @@ extern "C" fn shutdown_provider() {
     if let Err(e) = provider.shutdown() {
         println!("failed to shutdown provider: {:?}", e);
     }
-
 }
 
 pub fn init(level: LevelFilter) {

--- a/src/observability/tracing_for_test.rs
+++ b/src/observability/tracing_for_test.rs
@@ -1,10 +1,4 @@
-use std::{
-    cell::RefCell,
-    fmt::Debug,
-    io::Write,
-    sync::OnceLock,
-    thread,
-};
+use std::{cell::RefCell, fmt::Debug, io::Write, sync::OnceLock, thread};
 
 use itoa::Buffer;
 use libc::atexit;
@@ -117,7 +111,6 @@ impl SyncYamVisitor {
 
     #[inline]
     fn category_into(&self, buf: &mut Vec<u8>) {
-
         let col = self.collection.as_deref().unwrap_or("");
         let client = self.client.as_deref().unwrap_or("");
         let cuid = self.cuid.as_deref().unwrap_or("");

--- a/src/observability/tracing_for_test.rs
+++ b/src/observability/tracing_for_test.rs
@@ -28,10 +28,12 @@ static PROVIDER: OnceLock<Mutex<SdkTracerProvider>> = OnceLock::new();
 
 extern "C" fn shutdown_provider() {
     let provider = PROVIDER.get().unwrap();
-    provider
-        .lock()
-        .shutdown()
-        .expect("failed to shutdown provider");
+    let provider = provider.lock();
+
+    if let Err(e) = provider.shutdown() {
+        println!("failed to shutdown provider: {:?}", e);
+    }
+
 }
 
 pub fn init(level: LevelFilter) {

--- a/src/operations/body.rs
+++ b/src/operations/body.rs
@@ -1,0 +1,42 @@
+use std::fmt::{Debug, Formatter};
+
+use derive_more::Display;
+
+#[derive(Clone, Display)]
+pub enum OperationBody {
+    #[display("CounterIncrease({_0}")]
+    CounterIncrease(CounterIncreaseBody),
+}
+
+impl Debug for OperationBody {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+#[derive(Debug, Clone, Display)]
+#[display("delta={delta})")]
+pub struct CounterIncreaseBody {
+    delta: i64,
+}
+
+impl CounterIncreaseBody {
+    pub fn new(delta: i64) -> Self {
+        Self { delta }
+    }
+}
+
+#[cfg(test)]
+mod tests_operation_body {
+    use tracing::info;
+
+    use crate::operations::body::{CounterIncreaseBody, OperationBody};
+
+    #[test]
+    fn can_display_and_debug() {
+        let body = OperationBody::CounterIncrease(CounterIncreaseBody::new(123));
+        info!("{body} vs. {body:?}");
+        let s = body.to_string();
+        assert!(s.starts_with("CounterIncrease(") && s.ends_with(')'));
+    }
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,0 +1,65 @@
+use std::{
+    fmt::{Debug, Display, Formatter},
+    time::SystemTime,
+};
+
+use chrono::Local;
+
+use crate::operations::body::{CounterIncreaseBody, OperationBody};
+
+mod body;
+
+#[derive(Clone)]
+pub struct Operation {
+    lamport: u64,
+    body: OperationBody,
+    at: SystemTime,
+}
+
+impl Operation {
+    pub fn new(body: OperationBody) -> Self {
+        Self {
+            lamport: Default::default(),
+            body,
+            at: SystemTime::now(),
+        }
+    }
+
+    pub fn new_counter_increase(delta: i64) -> Self {
+        Self::new(OperationBody::CounterIncrease(CounterIncreaseBody::new(
+            delta,
+        )))
+    }
+}
+
+impl Debug for Operation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.to_string().as_str())
+    }
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "{}.{} {:?})",
+            self.lamport,
+            self.body,
+            chrono::DateTime::<Local>::from(self.at)
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests_operations {
+    use tracing::info;
+
+    use crate::operations::Operation;
+
+    #[test]
+    fn can_new_and_print_operations() {
+        let op = Operation::new_counter_increase(1);
+        info!("{op} vs. {op:?}");
+        let s = op.to_string();
+        assert_eq!(s, format!("{op:?}"));
+    }
+}

--- a/src/types/datatype.rs
+++ b/src/types/datatype.rs
@@ -8,10 +8,11 @@ pub enum DataType {
 }
 
 /// DatatypeState represents the state of a Datatype in SyncYam.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(i32)]
 pub enum DatatypeState {
     /// The Datatype is scheduled to be created on the SyncYam server.
+    #[default]
     DueToCreate = 0,
     /// The Datatype is scheduled to be subscribed on the SyncYam server.
     DueToSubscribe = 1,

--- a/src/types/datatype.rs
+++ b/src/types/datatype.rs
@@ -1,0 +1,30 @@
+/// DataType represents the kinds of Datatypes in SyncYam
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum DataType {
+    Counter = 0,
+    Variable = 1,
+    List = 2,
+}
+
+/// DatatypeState represents the state of a Datatype in SyncYam.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum DatatypeState {
+    /// The Datatype is scheduled to be created on the SyncYam server.
+    DueToCreate = 0,
+    /// The Datatype is scheduled to be subscribed on the SyncYam server.
+    DueToSubscribe = 1,
+    /// The Datatype is scheduled to be subscribed or created if it does not exist on the SyncYam server.
+    DueToSubscribeOrCreate = 2,
+    /// The Datatype has been subscribed on the SyncYam server.
+    Subscribed = 3,
+    /// The Datatype is scheduled to be unsubscribed from the SyncYam server.
+    DueToUnsubscribe = 4,
+    /// The Datatype is no longer synchronized with the SyncYam server.
+    Closed = 5,
+    /// The Datatype is scheduled to be deleted from the SyncYam server.
+    DueToDelete = 6,
+    /// The Datatype has been deleted and synchronized with the SyncYam server.
+    Deleted = 7,
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,2 +1,3 @@
+pub mod datatype;
 #[allow(dead_code)]
 pub mod uid;


### PR DESCRIPTION
- 🧬 feat(crdt): add `CounterCrdt` with serde support SyncYam 
- 🧩 chore: apply minor changes SyncYam 
- 🧬 feat(datatype): add thread-safe wrapper for MutableDatatype SyncYam

resolved #8 