### PR TITLE
🧬feat(datatype): implement rollback functionality and improve datatype operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,8 +1379,6 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "rstest",
- "serde",
- "serde_json",
  "thiserror",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,8 @@ tracing = [
     "dep:libc",
     "dep:once_cell",
     "dep:tracing-subscriber",
-    "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
-    "dep:tracing-opentelemetry",
     "dep:ctor",
 ]
 
@@ -23,10 +21,8 @@ tracing = [
 libc = { version = "^0.2.172", optional = true }
 once_cell = { version = "^1.21.3", optional = true }
 tracing-subscriber = { version = "^0.3.19", features = ["json", "fmt", "env-filter"], optional = true }
-opentelemetry = { version = "^0.30.0", optional = true }
 opentelemetry_sdk = { version = "^0.30.0", optional = true }
 opentelemetry-otlp = { version = "^0.30.0", features = ["grpc-tonic"], optional = true }
-tracing-opentelemetry = { version = "^0.31.0", optional = true }
 ctor = { version = "^0.5.0", optional = true }
 
 tracing = "^0.1.41"
@@ -37,9 +33,10 @@ time = { version = "^0.3", features = ["formatting", "local-offset", "macros"] }
 itoa = "^1.0.15"
 derive_more = { version = "^2.0.1", features = ["display", "debug"] }
 chrono = "0.4.41"
-serde = { version = "^1.0.219", features = ["derive", "rc"] }
-serde_json = "^1.0.143"
 thiserror = "^2.0.16"
+opentelemetry = { version = "^0.30.0" }
+tracing-opentelemetry = { version = "^0.31.0" }
+
 
 [dev-dependencies]
 rstest = "^0.26.1"

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -1,7 +1,5 @@
 use std::{error::Error, sync::Arc};
 
-use tracing::Span;
-
 use crate::{
     DataType, DatatypeError, DatatypeState, IntoString,
     datatypes::{
@@ -31,33 +29,125 @@ impl Counter {
     }
 
     datatype_instrument! {
+    /// Increases the counter by the specified delta value.
+    ///
+    /// Returns the new counter-value after the increment.
+    /// This operation is conflict-free and can be safely called concurrently.
+    ///
+    /// # Arguments
+    ///
+    /// * `delta` - The amount to increase the counter by (can be negative for decrease)
+    ///
+    /// # Returns
+    ///
+    /// The new counter-value after applying the increment
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use syncyam::{Counter, DatatypeState};
+    /// let counter = Counter::new("test".to_string(), DatatypeState::default());
+    /// assert_eq!(counter.increase_by(5), 5);
+    /// assert_eq!(counter.increase_by(-2), 3);
+    /// ```
     pub fn increase_by(&self, delta: i64) -> i64 {
-            let span = Span::current();
         let op = Operation::new_counter_increase(delta);
         match self
             .datatype
-            .execute_local_operation_as_tx(self.tx_ctx.clone(), op, span)
+            .execute_local_operation_as_tx(self.tx_ctx.clone(), op)
         {
             Ok(ReturnType::Counter(c)) => c,
             _ => self.get_value(),
         }
     }}
 
+    /// Increases the counter by 1.
+    ///
+    /// This is a convenience method equivalent to `increase_by(1)`.
+    ///
+    /// # Returns
+    ///
+    /// The new counter-value after incrementing by 1
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use syncyam::{Counter, DatatypeState};
+    /// let counter = Counter::new("test".to_string(), DatatypeState::default());
+    /// assert_eq!(counter.increase(), 1);
+    /// assert_eq!(counter.increase(), 2);
+    /// ```
     pub fn increase(&self) -> i64 {
         self.increase_by(1)
     }
 
+    /// Gets the current counter-value without modifying it.
+    ///
+    /// # Returns
+    ///
+    /// The current counter-value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use syncyam::{Counter, DatatypeState};
+    /// let counter = Counter::new("test".to_string(), DatatypeState::default());
+    /// assert_eq!(counter.get_value(), 0);
+    /// counter.increase();
+    /// assert_eq!(counter.get_value(), 1);
+    /// ```
     pub fn get_value(&self) -> i64 {
         let mutable = self.datatype.mutable.read();
         let Crdt::Counter(c) = &mutable.crdt;
         c.value()
     }
 
-    pub fn transaction(
+    datatype_instrument! {
+    /// Executes multiple operations atomically within a transaction.
+    ///
+    /// If the transaction function returns an error, all operations within
+    /// the transaction are rolled back, leaving the counter unchanged.
+    ///
+    /// # Arguments
+    ///
+    /// * `tag` - A descriptive label for the transaction
+    /// * `tx_func` - Function containing the operations to execute atomically
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the transaction succeeded, `Err(DatatypeError)` otherwise
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use syncyam::{Counter, DatatypeState};
+    /// let counter = Counter::new("test".to_string(), DatatypeState::default());
+    ///
+    /// // Successful transaction
+    /// let result = counter.transaction("batch-update", |c| {
+    ///     c.increase_by(10);
+    ///     c.increase_by(5);
+    ///     Ok(())
+    /// });
+    /// assert!(result.is_ok());
+    /// assert_eq!(counter.get_value(), 15);
+    ///
+    /// // Failed transaction - changes are rolled back
+    /// let result = counter.transaction("failing-update", |c| {
+    ///     c.increase_by(100);
+    ///     Err("something went wrong".into())
+    /// });
+    /// assert!(result.is_err());
+    /// assert_eq!(counter.get_value(), 15); // unchanged
+    /// ```
+    pub fn transaction<T>(
         &self,
         tag: impl IntoString,
-        tx_func: fn(Counter) -> Result<(), Box<dyn Error>>,
-    ) -> Result<(), DatatypeError> {
+        tx_func: T,
+    ) -> Result<(), DatatypeError>
+    where
+        T: FnOnce(Self) -> Result<(), Box<dyn Error + Send + Sync>> + Send + Sync + 'static,
+    {
         let this_tx_ctx = Arc::new(TransactionContext::new(tag));
         let this_tx_ctx_clone = this_tx_ctx.clone();
         let do_tx_func = move || {
@@ -69,8 +159,8 @@ impl Counter {
             }
         };
         self.datatype
-            .do_transaction(this_tx_ctx, do_tx_func, Span::current())
-    }
+            .do_transaction(this_tx_ctx, do_tx_func)
+    }}
 }
 
 impl DatatypeBlanket for Counter {
@@ -81,6 +171,9 @@ impl DatatypeBlanket for Counter {
 
 #[cfg(test)]
 mod tests_counter {
+    use tracing::{Span, info_span, instrument};
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
     use crate::{
         DataType,
         datatypes::{counter::Counter, datatype::Datatype},
@@ -101,10 +194,60 @@ mod tests_counter {
     }
 
     #[test]
-    fn can_execute_counter_operations() {
+    #[instrument]
+    fn can_use_counter_operations() {
         let counter = Counter::new(module_path!().to_owned(), Default::default());
         assert_eq!(1, counter.increase());
         assert_eq!(11, counter.increase_by(10));
         assert_eq!(11, counter.get_value());
+    }
+
+    #[test]
+    #[instrument]
+    fn can_use_transaction() {
+        let counter = Counter::new(module_path!().to_owned(), Default::default());
+        let result1 = counter.transaction("success", |c| {
+            c.increase_by(1);
+            c.increase_by(2);
+            Ok(())
+        });
+        assert!(result1.is_ok());
+        assert_eq!(3, counter.get_value());
+
+        let result2 = counter.transaction("failure", |c| {
+            c.increase_by(11);
+            c.increase_by(22);
+            Err("failed".into())
+        });
+        assert!(result2.is_err());
+        assert_eq!(3, counter.get_value());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[instrument]
+    async fn can_run_transactions_concurrently() {
+        let counter = Counter::new(module_path!().to_owned(), Default::default());
+        let mut join_handles = vec![];
+        let parent_span = Span::current();
+
+        for i in 0..5 {
+            let counter = counter.clone();
+            let parent_span = parent_span.clone();
+            join_handles.push(tokio::spawn(async move {
+                let thread_span = info_span!("run_transaction", i = i);
+                thread_span.set_parent(parent_span.context());
+                let _g1 = thread_span.enter();
+                let tag = format!("tag:{i}");
+                counter.transaction(tag, move |c| {
+                    c.increase_by(i);
+                    Ok(())
+                })
+            }));
+        }
+
+        for jh in join_handles {
+            let _ = jh.await.unwrap();
+        }
+        assert_eq!(1 + 2 + 3 + 4, counter.get_value());
     }
 }

--- a/src/datatypes/crdts/mod.rs
+++ b/src/datatypes/crdts/mod.rs
@@ -3,6 +3,7 @@ use crate::operations::body::OperationBody;
 use crate::{
     DataType, DatatypeError,
     datatypes::{common::ReturnType, crdts::counter_crdt::CounterCrdt},
+    errors::err,
     operations::Operation,
 };
 
@@ -25,12 +26,66 @@ impl Crdt {
         #[cfg(test)]
         {
             if let OperationBody::Delay4Test(body) = &op.body {
-                body.run();
-                return Ok(ReturnType::None);
+                return match body.run() {
+                    Ok(_) => Ok(ReturnType::None),
+                    Err(_) => Err(DatatypeError::FailedToExecuteOperation(body.to_string())),
+                };
             }
         }
         match self {
             Crdt::Counter(c) => c.execute_local_operation(op),
         }
+    }
+
+    pub fn serialize(&self) -> Box<[u8]> {
+        match self {
+            Self::Counter(c) => Box::new(c.to_bytes()),
+        }
+    }
+
+    pub fn deserialize(&mut self, serialized: &[u8]) {
+        match self {
+            Self::Counter(c) => {
+                if serialized.len() != 8 {
+                    err!(
+                        DatatypeError::FailedToDeserialize,
+                        format!(
+                            "counter crdt: {serialized:?}, and will recover to counter value 0"
+                        )
+                    );
+                    *c = CounterCrdt::default();
+                    return;
+                }
+                let mut array = [0u8; 8];
+                array.copy_from_slice(serialized);
+                *c = CounterCrdt::from_bytes(&array)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_crdts {
+    use crate::{
+        DataType,
+        datatypes::crdts::{Crdt, counter_crdt::CounterCrdt},
+    };
+
+    #[test]
+    fn can_serialize_and_deserialize() {
+        let mut counter = CounterCrdt::default();
+        counter.increase_by(100);
+        let crdt1 = Crdt::Counter(counter);
+
+        let mut crdt2 = Crdt::new(DataType::Counter);
+        let serialized = crdt1.serialize();
+        crdt2.deserialize(&serialized);
+
+        let Crdt::Counter(c) = &crdt2;
+        assert_eq!(c.value(), 100);
+        crdt2.deserialize("{}".as_bytes());
+
+        let Crdt::Counter(c) = &crdt2;
+        assert_eq!(c.value(), 0);
     }
 }

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -4,12 +4,13 @@ pub mod counter;
 mod crdts;
 pub mod datatype;
 mod mutable;
+mod rollback;
 mod transactional;
 
 macro_rules! datatype_instrument {
-
-    ($vis:vis fn $name:ident $($rest:tt)*) => {
-        #[tracing::instrument(skip(self),
+    ($(#[$attr:meta])* $vis:vis fn $name:ident $($rest:tt)*) => {
+        $(#[$attr])*
+        #[tracing::instrument(skip_all,
             fields(
                 syncyam.dt=%self.datatype.attr.key,
                 syncyam.duid=%self.datatype.attr.duid,

--- a/src/datatypes/rollback.rs
+++ b/src/datatypes/rollback.rs
@@ -1,0 +1,35 @@
+use std::{collections::VecDeque, fmt::Debug, sync::Arc};
+
+use crate::{
+    DatatypeState, operations::transaction::Transaction, types::operation_id::OperationId,
+};
+
+#[derive(Default)]
+pub struct RollbackData {
+    pub crdt: Box<[u8]>,
+    pub op_id: OperationId,
+    pub state: DatatypeState,
+    pub transactions: VecDeque<Arc<Transaction>>,
+}
+
+impl RollbackData {
+    pub fn push_transaction(&mut self, tx: Arc<Transaction>) {
+        self.transactions.push_back(tx);
+    }
+
+    pub fn set(&mut self, op_id: &OperationId, crdt: Box<[u8]>, state: DatatypeState) {
+        self.op_id = op_id.clone();
+        self.state = state;
+        self.crdt = crdt;
+        self.transactions.clear();
+    }
+}
+
+impl Debug for RollbackData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map()
+            .entry(&"tx len", &self.transactions.len())
+            .entry(&"crdt size", &self.crdt.len())
+            .finish()
+    }
+}

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
+use opentelemetry::KeyValue;
 use parking_lot::RwLock;
-use tracing::{Span, info_span, instrument};
+use tracing::{info_span, instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
     DataType, DatatypeState, IntoString,
@@ -76,6 +78,7 @@ pub struct TransactionalDatatype {
     pub attr: Attributes,
     pub mutable: RwLock<MutableDatatype>,
     tx_ctx: RwLock<Option<Arc<TransactionContext>>>,
+    op_mutex: NoGuardMutex,
     tx_mutex: NoGuardMutex,
 }
 
@@ -100,29 +103,36 @@ impl TransactionalDatatype {
             r#type,
             duid: Duid::new(),
         };
-        Self {
+        let transactional = Self {
             attr,
             mutable: RwLock::new(MutableDatatype::new(r#type, state)),
             tx_ctx: Default::default(),
+            op_mutex: Default::default(),
             tx_mutex: Default::default(),
-        }
+        };
+        transactional.set_rollback_data();
+        transactional
     }
 
-    #[instrument(skip_all, parent = _parent_span)]
+    fn set_rollback_data(&self) {
+        let mut mutable = self.mutable.write();
+        mutable.set_rollback();
+    }
+
     pub fn execute_local_operation_as_tx(
         &self,
         tx_ctx: Arc<TransactionContext>,
         op: Operation,
-        _parent_span: Span,
     ) -> Result<ReturnType, DatatypeError> {
-        let span = Span::current();
         let mut _defer_guard = None;
+        let begin_span = info_span!("begin_operation");
+        let g_begin_span = begin_span.enter();
         loop {
-            match self.begin_transaction(tx_ctx.clone(), &span) {
+            match self.begin_transaction(tx_ctx.clone()) {
                 BeginTransactionResult::BeginTx(mut dg) => {
-                    dg.add_defer_func(move |_committed| {
-                        self.tx_mutex.unlock();
-                    });
+                    begin_span.add_event("BeginTx", vec![]);
+                    drop(g_begin_span);
+
                     dg.commit();
                     _defer_guard = Some(dg);
                     break;
@@ -130,25 +140,27 @@ impl TransactionalDatatype {
                 BeginTransactionResult::SameCtx => {
                     // After the first call inside do_transaction, subsequent execute_local_operation_as_tx calls in tx_func run as SameCtx.
                     // If execute_local_operation_as_tx is invoked from another thread, the tx_mutex can ensure exclusive execution.
-                    let mut dg = DeferGuard::new();
-                    dg.add_defer_func(move |_committed| {
-                        self.tx_mutex.unlock();
-                    });
-                    _defer_guard = Some(dg);
+                    begin_span.add_event("SameCtx", vec![]);
+                    drop(g_begin_span);
+                    _defer_guard = Some(DeferGuard::new());
                     break;
                 }
                 BeginTransactionResult::OtherCtx => {
+                    begin_span.add_event("OtherCtx", vec![]);
                     // For OtherCtx, begin_transaction is repeatedly attempted until it transitions to BeginTx.
                     // If an operation is already running, the tx_mutex is locked, so we wait until we can acquire the tx_mutex lock.
                     self.wait_for_mutex();
-                    std::thread::yield_now();
                 }
             }
         }
-        self.tx_mutex.lock();
+        let defer_guard = _defer_guard.as_mut().unwrap();
+        self.op_mutex.lock();
+        defer_guard.add_defer_func(move |_committed| {
+            self.op_mutex.unlock();
+        });
         let mut mutable = self.mutable.write();
         let ret = mutable.execute_local_operation(op)?;
-        _defer_guard.as_mut().unwrap().commit();
+        defer_guard.commit();
         Ok(ret)
     }
 
@@ -157,14 +169,10 @@ impl TransactionalDatatype {
         let mut mutable = self.mutable.write();
         mutable.end_transaction(tag, committed);
         self.tx_ctx.write().take();
+        self.tx_mutex.unlock();
     }
 
-    #[instrument(skip_all, parent=_parent_span, fields(tag=tx_ctx.tag))]
-    fn begin_transaction(
-        &self,
-        tx_ctx: Arc<TransactionContext>,
-        _parent_span: &Span,
-    ) -> BeginTransactionResult {
+    fn begin_transaction(&self, tx_ctx: Arc<TransactionContext>) -> BeginTransactionResult {
         let mut self_tx_ctx = self.tx_ctx.write();
         // self.tx_ctx defaults to None when no transaction is active.
         // Once a transaction begins, self.tx_ctx is set to the current transaction context.
@@ -198,22 +206,25 @@ impl TransactionalDatatype {
         }
     }
 
-    #[instrument(skip_all, parent=_parent_span)]
     pub fn do_transaction<F>(
         &self,
         tx_ctx: Arc<TransactionContext>,
         tx_func: F,
-        _parent_span: Span,
     ) -> Result<(), DatatypeError>
     where
         F: FnOnce() -> Result<(), DatatypeError>,
     {
-        let parent_span = Span::current();
+        let begin_span = info_span!("begin_transaction");
+        let g_begin_span = begin_span.enter();
+        let mut retries = 0;
         loop {
-            match self.begin_transaction(tx_ctx.clone(), &parent_span) {
+            match self.begin_transaction(tx_ctx.clone()) {
                 BeginTransactionResult::BeginTx(mut dg) => {
-                    let span = info_span!("tx_func");
-                    return span.in_scope(|| tx_func().inspect(|_x| dg.commit()));
+                    self.tx_mutex.lock();
+                    begin_span.add_event("BeginTx", vec![KeyValue::new("retries", retries)]);
+                    drop(g_begin_span);
+                    let tx_func_span = info_span!("tx_func");
+                    return tx_func_span.in_scope(|| tx_func().inspect(|_x| dg.commit()));
                 }
                 BeginTransactionResult::SameCtx => {
                     // do_transaction should not / cannot be called with the same tx_ctx from different threads
@@ -222,8 +233,10 @@ impl TransactionalDatatype {
                     );
                 }
                 BeginTransactionResult::OtherCtx => {
+                    retries += 1;
+                    begin_span.add_event("OtherCtx", vec![KeyValue::new("retries", retries)]);
                     // This can occur when the current transaction cannot begin due to any other concurrent operation or transaction.
-                    self.wait_for_mutex();
+                    self.wait_for_tx_mutex();
                 }
             }
         }
@@ -231,6 +244,12 @@ impl TransactionalDatatype {
 
     #[inline]
     fn wait_for_mutex(&self) {
+        self.op_mutex.lock();
+        self.op_mutex.unlock();
+    }
+
+    #[inline]
+    fn wait_for_tx_mutex(&self) {
         self.tx_mutex.lock();
         self.tx_mutex.unlock();
     }
@@ -241,7 +260,8 @@ mod tests_transactional {
     use std::sync::Arc;
 
     use parking_lot::Mutex;
-    use tracing::{Span, info, info_span};
+    use tracing::{Span, info, info_span, instrument};
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
 
     use crate::{
         DataType, DatatypeState,
@@ -249,36 +269,68 @@ mod tests_transactional {
         operations::Operation,
     };
 
+    #[test]
+    #[instrument]
+    fn can_fail_operation_execution() {
+        let tx_dt = Arc::new(TransactionalDatatype::new(
+            "can_fail_operation_execution",
+            DataType::Counter,
+            DatatypeState::default(),
+        ));
+        {
+            let mutable = tx_dt.mutable.write();
+            assert_eq!(0, mutable.op_id.cseq);
+            assert!(mutable.transaction.is_none());
+            assert_eq!(0, mutable.rollback.transactions.len());
+        }
+
+        let op1 = Operation::new_delay_for_test(10, true);
+        let result1 = tx_dt.execute_local_operation_as_tx(Default::default(), op1);
+        assert!(result1.is_ok());
+        {
+            let mutable = tx_dt.mutable.write();
+            assert_eq!(1, mutable.op_id.cseq);
+            assert!(mutable.transaction.is_none());
+            assert_eq!(1, mutable.rollback.transactions.len());
+        }
+
+        let op2 = Operation::new_delay_for_test(10, false);
+        let result2 = tx_dt.execute_local_operation_as_tx(Default::default(), op2);
+        assert!(result2.is_err());
+        {
+            let mutable = tx_dt.mutable.write();
+            assert_eq!(1, mutable.op_id.cseq);
+            assert_eq!(1, mutable.rollback.transactions.len());
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[instrument]
     async fn can_do_transaction() {
         let tx_dt = Arc::new(TransactionalDatatype::new(
             "can_do_transaction",
             DataType::Counter,
             DatatypeState::default(),
         ));
-        let span = info_span!("test_do_transaction");
-        let _guard = span.enter();
+        let parent_span = Span::current();
 
         let mut join_handles = vec![];
 
         for i in 0..5 {
             let tx_dt = tx_dt.clone();
-            let parent_span = span.clone();
+            let parent_span = parent_span.clone();
             join_handles.push(tokio::spawn(async move {
+                let thread_span = info_span!("thread", i = i);
+                thread_span.set_parent(parent_span.context());
+                let _g_thread_span = thread_span.enter();
                 let tx_ctx = Arc::new(TransactionContext::new(format!("test_tx_{i}")));
-                tx_dt.clone().do_transaction(
-                    tx_ctx.clone(),
-                    move || {
-                        let span = Span::current();
-                        tx_dt.execute_local_operation_as_tx(
-                            tx_ctx.clone(),
-                            Operation::new_delay_for_test(1),
-                            span,
-                        )?;
-                        Ok(())
-                    },
-                    parent_span.clone(),
-                )
+                tx_dt.clone().do_transaction(tx_ctx.clone(), move || {
+                    tx_dt.execute_local_operation_as_tx(
+                        tx_ctx.clone(),
+                        Operation::new_delay_for_test(1, true),
+                    )?;
+                    Ok(())
+                })
             }));
         }
         for jh in join_handles {
@@ -287,14 +339,15 @@ mod tests_transactional {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    #[instrument]
     async fn can_execute_the_same_tx_ctx_continuously_with_none_tx_ctx() {
         let tx_dt = Arc::new(TransactionalDatatype::new(
             module_path!(),
             DataType::Counter,
             Default::default(),
         ));
-        let span = info_span!("test_continuously_tx_ctx");
-        let _span_guard = span.enter();
+        let parent_span = Span::current();
+        let _span_guard = parent_span.enter();
         let tx_ctx_with_tag = Arc::new(TransactionContext::new("test_tx"));
         let tx_ctx_with_no_tag: Arc<TransactionContext> = Default::default();
         let mut join_handles = vec![];
@@ -303,13 +356,14 @@ mod tests_transactional {
             {
                 let tx_dt = tx_dt.clone();
                 let tx_ctx = tx_ctx_with_tag.clone();
-                let op = Operation::new_delay_for_test(50);
-                let parent_span = span.clone();
+                let op = Operation::new_delay_for_test(5, true);
+                let parent_span = parent_span.clone();
                 let executions = executions.clone();
                 join_handles.push(tokio::spawn(async move {
-                    tx_dt
-                        .execute_local_operation_as_tx(tx_ctx, op, parent_span)
-                        .unwrap();
+                    let thread_span = info_span!("thread_with_tag", i = i);
+                    thread_span.set_parent(parent_span.context());
+                    let _g_thread_span = thread_span.enter();
+                    tx_dt.execute_local_operation_as_tx(tx_ctx, op).unwrap();
                     executions.lock().push(-(i + 1));
                     info!("with tag:{i}");
                 }));
@@ -317,13 +371,14 @@ mod tests_transactional {
             {
                 let tx_dt = tx_dt.clone();
                 let tx_ctx = tx_ctx_with_no_tag.clone();
-                let op = Operation::new_delay_for_test(50);
+                let op = Operation::new_delay_for_test(5, true);
+                let parent_span = parent_span.clone();
                 let executions = executions.clone();
                 join_handles.push(tokio::spawn(async move {
-                    let span = Span::current();
-                    tx_dt
-                        .execute_local_operation_as_tx(tx_ctx, op, span)
-                        .unwrap();
+                    let thread_span = info_span!("thread_with_no_tag", i = i);
+                    thread_span.set_parent(parent_span.context());
+                    let _g_thread_span = thread_span.enter();
+                    tx_dt.execute_local_operation_as_tx(tx_ctx, op).unwrap();
                     executions.lock().push(i + 1);
                     info!("with no tag:{i}");
                 }));

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,1 +1,16 @@
 pub mod datatypes;
+
+macro_rules! err {
+    ($enum_variant:path) => {{
+        let err = $enum_variant("".to_string());
+        tracing::error!("{}\n{}", err, std::backtrace::Backtrace::capture());
+        err
+    }};
+
+    ($enum_variant:path, $msg:expr) => {{
+        let err = $enum_variant(std::format!("{}", $msg));
+        tracing::error!("{}\n{}", err, std::backtrace::Backtrace::capture());
+    }};
+}
+
+pub(crate) use err;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,15 @@ pub(crate) mod utils;
 
 pub trait IntoString: Into<String> + Debug {}
 
+/// A trait for types that can be converted into a String and debugged.
+///
+/// This trait combines `Into<String>` and `Debug` bounds for convenience
+/// in function parameters that need both string conversion and debug output.
+///
+/// # Note
+///
+/// This trait is automatically implemented for all types that satisfy
+/// both `Into<String>` and `Debug`.
 impl<T: Into<String> + Debug> IntoString for T {}
 
 #[cfg(feature = "tracing")]

--- a/src/operations/body.rs
+++ b/src/operations/body.rs
@@ -22,17 +22,22 @@ impl Debug for OperationBody {
 #[display("")]
 pub struct Delay4TestBody {
     duration_ms: u64,
+    success: bool,
 }
 
 #[cfg(test)]
 impl Delay4TestBody {
-    pub fn new(duration_ms: u64) -> Self {
-        Self { duration_ms }
+    pub fn new(duration_ms: u64, success: bool) -> Self {
+        Self {
+            duration_ms,
+            success,
+        }
     }
 
-    pub fn run(&self) {
+    pub fn run(&self) -> Result<(), ()> {
         use std::{thread::sleep, time::Duration};
         sleep(Duration::from_millis(self.duration_ms));
+        if self.success { Ok(()) } else { Err(()) }
     }
 }
 

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -14,7 +14,7 @@ pub mod transaction;
 
 #[derive(Clone)]
 pub struct Operation {
-    lamport: u64,
+    pub lamport: u64,
     pub body: OperationBody,
     at: SystemTime,
 }
@@ -35,8 +35,11 @@ impl Operation {
     }
 
     #[cfg(test)]
-    pub fn new_delay_for_test(duration_ms: u64) -> Self {
-        Self::new(OperationBody::Delay4Test(Delay4TestBody::new(duration_ms)))
+    pub fn new_delay_for_test(duration_ms: u64, success: bool) -> Self {
+        Self::new(OperationBody::Delay4Test(Delay4TestBody::new(
+            duration_ms,
+            success,
+        )))
     }
 
     pub fn set_lamport(&mut self, lamport: u64) {

--- a/src/operations/transaction.rs
+++ b/src/operations/transaction.rs
@@ -15,6 +15,10 @@ pub struct Transaction {
 }
 
 impl Transaction {
+    pub fn cuid(&self) -> &Cuid {
+        &self.cuid
+    }
+
     pub fn new(op_id: &mut OperationId) -> Self {
         Self {
             cuid: op_id.cuid.clone(),
@@ -42,6 +46,10 @@ impl Transaction {
 
     pub fn push_operation(&mut self, op: Operation) {
         self.operations.push(op);
+    }
+
+    pub fn iter_operation(&self, c: impl FnMut(&Operation)) {
+        self.operations.iter().for_each(c);
     }
 }
 

--- a/src/types/operation_id.rs
+++ b/src/types/operation_id.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::types::uid::Cuid;
 
-#[derive(PartialEq, Default)]
+#[derive(PartialEq, Default, Clone)]
 pub struct OperationId {
     pub lamport: u64,
     pub cuid: Cuid,


### PR DESCRIPTION
- fixed #14 

- Add rollback.rs with RollbackData struct for transaction rollback support
- Enhance Counter datatype with comprehensive documentation and improved operations
- Refactor TransactionalDatatype with rollback capabilities and operation mutex
- Improve error handling with new datatype error types
- Clean up Cargo.toml dependencies and reorganize tracing features
- Add operation mutex to prevent concurrent operation conflicts
- Update CRDT implementations to support rollback functionality

This commit introduces robust rollback mechanisms for distributed operations while maintaining backward compatibility and improving overall system reliability.