### PR TITLE
🧬feat(client): add Client API for create/subscribe, DatatypeSet, and client-scoped tracing

### DIFF
--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::{
+    Counter, DataType, DatatypeState, IntoString, clients::datatype_manager::DatatypeManager,
+    datatypes::DatatypeSet, errors::clients::ClientError, types::uid::Cuid,
+};
+
+pub struct ClientBuilder {
+    collection: String,
+    alias: String,
+    cuid: Cuid,
+}
+
+impl ClientBuilder {
+    pub fn build(self) -> Result<Client, ClientError> {
+        let client_info = Arc::new(ClientInfo {
+            collection: self.collection.into_boxed_str(),
+            cuid: self.cuid,
+            alias: self.alias.into_boxed_str(),
+        });
+
+        Ok(Client {
+            info: client_info.clone(),
+            datatypes: RwLock::new(DatatypeManager::new(client_info.clone())),
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct ClientInfo {
+    pub collection: Box<str>,
+    pub cuid: Cuid,
+    pub alias: Box<str>,
+}
+
+pub struct Client {
+    info: Arc<ClientInfo>,
+    datatypes: RwLock<DatatypeManager>,
+}
+
+impl Client {
+    pub fn builder(collection: impl IntoString, alias: impl IntoString) -> ClientBuilder {
+        ClientBuilder {
+            collection: collection.into(),
+            alias: alias.into(),
+            cuid: Cuid::new(),
+        }
+    }
+
+    fn subscribe_or_create_datatype(
+        &self,
+        key: String,
+        r#type: DataType,
+        state: DatatypeState,
+    ) -> Result<DatatypeSet, ClientError> {
+        self.datatypes
+            .write()
+            .subscribe_or_create_datatype(&key, r#type, state)
+    }
+
+    pub fn subscribe_counter(&self, key: impl IntoString) -> Result<Counter, ClientError> {
+        let ds = self.subscribe_or_create_datatype(
+            key.into(),
+            DataType::Counter,
+            DatatypeState::DueToSubscribe,
+        )?;
+        let DatatypeSet::Counter(counter) = ds;
+        Ok(counter)
+    }
+
+    pub fn create_counter(&self, key: impl IntoString) -> Result<Counter, ClientError> {
+        let ds = self.subscribe_or_create_datatype(
+            key.into(),
+            DataType::Counter,
+            DatatypeState::DueToCreate,
+        )?;
+        let DatatypeSet::Counter(counter) = ds;
+        Ok(counter)
+    }
+
+    pub fn subscribe_or_create_counter(
+        &self,
+        key: impl IntoString,
+    ) -> Result<Counter, ClientError> {
+        let ds = self.subscribe_or_create_datatype(
+            key.into(),
+            DataType::Counter,
+            DatatypeState::DueToSubscribeOrCreate,
+        )?;
+        let DatatypeSet::Counter(counter) = ds;
+        Ok(counter)
+    }
+
+    pub fn get_datatype(&self, key: &str) -> Option<DatatypeSet> {
+        self.datatypes.read().get_datatype(key)
+    }
+
+    pub fn get_collection(&self) -> &str {
+        &self.info.collection
+    }
+
+    pub fn get_alias(&self) -> &str {
+        &self.info.alias
+    }
+}
+
+#[cfg(test)]
+mod tests_client {
+    use crate::{Datatype, DatatypeState, clients::client::Client};
+
+    #[test]
+    fn can_assert_send_and_sync_traits() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Client>();
+    }
+
+    #[test]
+    fn can_build_client() {
+        let client = Client::builder("collection1", "alias1").build().unwrap();
+        assert_eq!(client.get_collection(), "collection1");
+        assert_eq!(client.get_alias(), "alias1");
+    }
+
+    #[test]
+    fn can_use_counter_from_client() {
+        let client1 = Client::builder(module_path!(), module_path!())
+            .build()
+            .unwrap();
+
+        assert!(client1.get_datatype("k1").is_none());
+
+        let counter1 = client1.subscribe_counter("k1").unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::DueToSubscribe);
+        assert!(client1.get_datatype("k1").is_some());
+
+        let client2 = Client::builder(module_path!(), module_path!())
+            .build()
+            .unwrap();
+        let counter2 = client2.create_counter("k1").unwrap();
+        assert_eq!(counter2.get_state(), DatatypeState::DueToCreate);
+
+        let client3 = Client::builder(module_path!(), module_path!())
+            .build()
+            .unwrap();
+        let counter3 = client3.subscribe_or_create_counter("k1").unwrap();
+        assert_eq!(counter3.get_state(), DatatypeState::DueToSubscribeOrCreate);
+    }
+}

--- a/src/clients/datatype_manager.rs
+++ b/src/clients/datatype_manager.rs
@@ -36,7 +36,7 @@ impl DatatypeManager {
                 let existing = entry.get();
                 if existing.get_type() != r#type || existing.get_state() != state {
                     return Err(err!(
-                        ClientError::CannotSubscribeOrCreateDatatype,
+                        ClientError::FailedToSubscribeOrCreateDatatype,
                         format!(
                             "{type:?} is demanded as {state:?}, but the clients has {:?} for '{key}' as {:?}",
                             existing.get_type(),
@@ -73,7 +73,7 @@ mod tests_datatype_manager {
             dm.subscribe_or_create_datatype("k1", DataType::List, DatatypeState::DueToCreate);
         assert_eq!(
             res2.err().unwrap(),
-            ClientError::CannotSubscribeOrCreateDatatype("".into())
+            ClientError::FailedToSubscribeOrCreateDatatype("".into())
         );
 
         let res3 = dm.subscribe_or_create_datatype(
@@ -83,7 +83,7 @@ mod tests_datatype_manager {
         );
         assert_eq!(
             res3.err().unwrap(),
-            ClientError::CannotSubscribeOrCreateDatatype("".into())
+            ClientError::FailedToSubscribeOrCreateDatatype("".into())
         );
 
         let res4 =

--- a/src/clients/datatype_manager.rs
+++ b/src/clients/datatype_manager.rs
@@ -1,0 +1,95 @@
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    sync::Arc,
+};
+
+use crate::{
+    ClientError, DataType, DatatypeState, clients::client::ClientInfo, datatypes::DatatypeSet,
+    errors::err,
+};
+
+pub struct DatatypeManager {
+    info: Arc<ClientInfo>,
+    datatypes: HashMap<String, DatatypeSet>,
+}
+
+impl DatatypeManager {
+    pub fn new(client_info: Arc<ClientInfo>) -> Self {
+        Self {
+            datatypes: HashMap::new(),
+            info: client_info,
+        }
+    }
+
+    pub fn get_datatype(&self, key: &str) -> Option<DatatypeSet> {
+        self.datatypes.get(key).cloned()
+    }
+
+    pub fn subscribe_or_create_datatype(
+        &mut self,
+        key: &str,
+        r#type: DataType,
+        state: DatatypeState,
+    ) -> Result<DatatypeSet, ClientError> {
+        match self.datatypes.entry(key.to_owned()) {
+            Entry::Occupied(entry) => {
+                let existing = entry.get();
+                if existing.get_type() != r#type || existing.get_state() != state {
+                    return Err(err!(
+                        ClientError::CannotSubscribeOrCreateDatatype,
+                        format!(
+                            "{type:?} is demanded as {state:?}, but the clients has {:?} for '{key}' as {:?}",
+                            existing.get_type(),
+                            existing.get_state()
+                        )
+                    ));
+                }
+                Ok(existing.clone())
+            }
+            Entry::Vacant(_) => {
+                let dt = DatatypeSet::new(r#type, key, state, self.info.clone());
+                self.datatypes.insert(key.to_owned(), dt.clone());
+                Ok(dt)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_datatype_manager {
+    use crate::{ClientError, DataType, DatatypeState, clients::datatype_manager::DatatypeManager};
+
+    #[test]
+    fn can_use_subscribe_or_create_datatype() {
+        let mut dm = DatatypeManager::new(Default::default());
+        let res1 =
+            dm.subscribe_or_create_datatype("k1", DataType::Counter, DatatypeState::DueToCreate);
+        assert!(res1.is_ok());
+        let dt1 = res1.unwrap();
+        assert_eq!(dt1.get_type(), DataType::Counter);
+        assert_eq!(dt1.get_state(), DatatypeState::DueToCreate);
+
+        let res2 =
+            dm.subscribe_or_create_datatype("k1", DataType::List, DatatypeState::DueToCreate);
+        assert_eq!(
+            res2.err().unwrap(),
+            ClientError::CannotSubscribeOrCreateDatatype("".into())
+        );
+
+        let res3 = dm.subscribe_or_create_datatype(
+            "k1",
+            DataType::Counter,
+            DatatypeState::DueToSubscribeOrCreate,
+        );
+        assert_eq!(
+            res3.err().unwrap(),
+            ClientError::CannotSubscribeOrCreateDatatype("".into())
+        );
+
+        let res4 =
+            dm.subscribe_or_create_datatype("k1", DataType::Counter, DatatypeState::DueToCreate);
+        assert!(res4.is_ok());
+        let dt4 = res4.unwrap();
+        assert_eq!(dt4.get_state(), DatatypeState::DueToCreate);
+    }
+}

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+mod datatype_manager;

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -11,11 +11,12 @@ use crate::{DataType, DatatypeState, datatypes::transactional::TransactionalData
 ///
 /// # Example
 /// ```
+/// use syncyam::Client;
 /// use syncyam::{Counter, Datatype};
 /// use syncyam::{DatatypeState, DataType};
-/// // TODO: this should be updated to create a Counter from a client
-/// let counter = Counter::new("example".to_string(), DatatypeState::DueToCreate);
-/// assert_eq!(counter.get_key(), "example");
+/// let client = Client::builder("test-collection", "test-client").build().unwrap();
+/// let counter = client.create_counter("test-counter".to_string()).unwrap();
+/// assert_eq!(counter.get_key(), "test-counter");
 /// assert_eq!(counter.get_type(), DataType::Counter);
 /// assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
 /// ```
@@ -56,7 +57,12 @@ mod tests_datatype_trait {
     #[test]
     fn can_call_datatype_trait_functions() {
         let key = module_path!();
-        let data = TransactionalDatatype::new(key, DataType::Counter, DatatypeState::DueToCreate);
+        let data = TransactionalDatatype::new(
+            key,
+            DataType::Counter,
+            Default::default(),
+            Default::default(),
+        );
         assert_eq!(data.get_key(), key);
         assert_eq!(data.get_type(), DataType::Counter);
         assert_eq!(data.get_state(), DatatypeState::DueToCreate);

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -29,24 +29,34 @@ pub(crate) use datatype_instrument;
 
 use crate::{Counter, DataType, Datatype, DatatypeState, clients::client::ClientInfo};
 
+/// A typed wrapper for concrete datatypes managed by the client.
+///
+/// `DatatypeSet` allows returning a single enum while preserving
+/// type information and shared behavior across datatypes.
 #[derive(Clone)]
 pub enum DatatypeSet {
     Counter(Counter),
 }
 
 impl DatatypeSet {
+    /// Returns the logical [`DataType`] of this set member.
     pub fn get_type(&self) -> DataType {
         match self {
             DatatypeSet::Counter(_) => DataType::Counter,
         }
     }
 
+    /// Returns the current [`DatatypeState`].
     pub fn get_state(&self) -> DatatypeState {
         match self {
             DatatypeSet::Counter(cnt) => cnt.get_state(),
         }
     }
 
+    /// Creates a new [`DatatypeSet`] instance for the given `type` and `key`.
+    ///
+    /// This is primarily used by the client internals to construct
+    /// a concrete datatype variant tied to a specific client context.
     pub fn new(
         r#type: DataType,
         key: &str,

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -12,6 +12,9 @@ macro_rules! datatype_instrument {
         $(#[$attr])*
         #[tracing::instrument(skip_all,
             fields(
+                syncyam.col=%self.datatype.attr.client_info.collection,
+                syncyam.cl=%self.datatype.attr.client_info.alias,
+                syncyam.cuid=%self.datatype.attr.client_info.cuid,
                 syncyam.dt=%self.datatype.attr.key,
                 syncyam.duid=%self.datatype.attr.duid,
             )
@@ -20,4 +23,83 @@ macro_rules! datatype_instrument {
     };
 }
 
+use std::sync::Arc;
+
 pub(crate) use datatype_instrument;
+
+use crate::{Counter, DataType, Datatype, DatatypeState, clients::client::ClientInfo};
+
+#[derive(Clone)]
+pub enum DatatypeSet {
+    Counter(Counter),
+}
+
+impl DatatypeSet {
+    pub fn get_type(&self) -> DataType {
+        match self {
+            DatatypeSet::Counter(_) => DataType::Counter,
+        }
+    }
+
+    pub fn get_state(&self) -> DatatypeState {
+        match self {
+            DatatypeSet::Counter(cnt) => cnt.get_state(),
+        }
+    }
+
+    pub fn new(
+        r#type: DataType,
+        key: &str,
+        state: DatatypeState,
+        client_info: Arc<ClientInfo>,
+    ) -> Self {
+        match r#type {
+            DataType::Counter => {
+                DatatypeSet::Counter(Counter::new(key.to_owned(), state, client_info))
+            }
+            _ => {
+                todo!()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_datatype_set {
+    use crate::{
+        Counter, DataType, Datatype, DatatypeState,
+        datatypes::{DatatypeSet, datatype::DatatypeBlanket, transactional::TransactionalDatatype},
+    };
+
+    #[test]
+    fn can_clone_datatype_set() {
+        let ds1 = DatatypeSet::new(
+            DataType::Counter,
+            "k1",
+            DatatypeState::DueToCreate,
+            Default::default(),
+        );
+        let ds2 = ds1.clone();
+        let DatatypeSet::Counter(cnt1) = ds1;
+        let DatatypeSet::Counter(cnt2) = ds2;
+
+        // Cloned DatatypeSet contains a cloned Counter (same variant, same key)
+        assert_eq!(cnt1.get_key(), cnt2.get_key());
+        assert_eq!(cnt1.get_type(), cnt2.get_type());
+
+        // Verify the cloned Counter operates correctly and shares state
+        assert_eq!(0, cnt1.get_value());
+        assert_eq!(2, cnt2.increase_by(2));
+        assert_eq!(2, cnt1.get_value());
+
+        // Verify the cloned Counter is different from the original
+        let ptr1: *const Counter = &cnt1;
+        let ptr2: *const Counter = &cnt2;
+        assert_ne!(ptr1, ptr2);
+
+        // Verify the cloned Counter has the same TransactionalDatatype as the original
+        let ptr1: *const TransactionalDatatype = cnt1.get_core();
+        let ptr2: *const TransactionalDatatype = cnt2.get_core();
+        assert_eq!(ptr1, ptr2);
+    }
+}

--- a/src/errors/clients.rs
+++ b/src/errors/clients.rs
@@ -1,9 +1,20 @@
 use thiserror::Error;
 
+/// Errors related to client-side operations and datatype management.
+///
+/// # Equality
+/// Two `ClientError` values are considered equal if they are the **same variant**,
+/// regardless of their message payload. See the custom `PartialEq` implementation.
+///
 #[derive(Debug, Error)]
 pub enum ClientError {
+    /// Subscribe or Create Datatype failed.
+    ///
+    /// Returned when a request to subscribe or create a datatype is
+    /// incompatible with an existing instance for the same key (for
+    /// example, mismatched type or datatype state).
     #[error("Cannot subscribe or create datatype: {0}")]
-    CannotSubscribeOrCreateDatatype(String),
+    FailedToSubscribeOrCreateDatatype(String),
 }
 
 impl PartialEq for ClientError {

--- a/src/errors/clients.rs
+++ b/src/errors/clients.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("Cannot subscribe or create datatype: {0}")]
+    CannotSubscribeOrCreateDatatype(String),
+}
+
+impl PartialEq for ClientError {
+    fn eq(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -40,25 +40,3 @@ impl PartialEq for DatatypeError {
         std::mem::discriminant(self) == std::mem::discriminant(other)
     }
 }
-
-#[cfg(test)]
-mod tests_datatype_errors {
-    use super::*;
-    use crate::errors::err;
-
-    #[test]
-    fn can_compare_datatypes_errors() {
-        let e1 = DatatypeError::FailedTransaction("e1".to_string());
-        let e2 = DatatypeError::FailedTransaction("e2".to_string());
-        assert_eq!(e1, e2);
-
-        let e3 = DatatypeError::FailedToDeserialize("e2".to_string());
-        assert_ne!(e2, e3);
-    }
-
-    #[test]
-    fn can_use_err_macro() {
-        err!(DatatypeError::FailedToDeserialize, "hello");
-        err!(DatatypeError::FailedTransaction);
-    }
-}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -37,10 +37,10 @@ mod tests_datatype_errors {
         let d2 = err!(DatatypeError::FailedTransaction);
         assert_ne!(d1, d2);
         let c1 = err!(
-            ClientError::CannotSubscribeOrCreateDatatype,
+            ClientError::FailedToSubscribeOrCreateDatatype,
             "clients error"
         );
-        let c2 = err!(ClientError::CannotSubscribeOrCreateDatatype);
+        let c2 = err!(ClientError::FailedToSubscribeOrCreateDatatype);
         assert_eq!(c1, c2);
     }
 }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,3 +1,4 @@
+pub mod clients;
 pub mod datatypes;
 
 macro_rules! err {
@@ -10,7 +11,36 @@ macro_rules! err {
     ($enum_variant:path, $msg:expr) => {{
         let err = $enum_variant(std::format!("{}", $msg));
         tracing::error!("{}\n{}", err, std::backtrace::Backtrace::capture());
+        err
     }};
 }
 
 pub(crate) use err;
+
+#[cfg(test)]
+mod tests_datatype_errors {
+    use crate::{ClientError, DatatypeError, errors::err};
+
+    #[test]
+    fn can_compare_errors() {
+        let e1 = DatatypeError::FailedTransaction("e1".to_string());
+        let e2 = DatatypeError::FailedTransaction("e2".to_string());
+        assert_eq!(e1, e2);
+
+        let e3 = DatatypeError::FailedToDeserialize("e2".to_string());
+        assert_ne!(e2, e3);
+    }
+
+    #[test]
+    fn can_use_err_macro() {
+        let d1 = err!(DatatypeError::FailedToDeserialize, "datatype error");
+        let d2 = err!(DatatypeError::FailedTransaction);
+        assert_ne!(d1, d2);
+        let c1 = err!(
+            ClientError::CannotSubscribeOrCreateDatatype,
+            "clients error"
+        );
+        let c2 = err!(ClientError::CannotSubscribeOrCreateDatatype);
+        assert_eq!(c1, c2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 use std::fmt::Debug;
 
 pub use crate::{
-    datatypes::{counter::Counter, datatype::Datatype},
-    errors::datatypes::DatatypeError,
+    clients::client::Client,
+    datatypes::{DatatypeSet, counter::Counter, datatype::Datatype},
+    errors::{clients::ClientError, datatypes::DatatypeError},
     types::datatype::{DataType, DatatypeState},
 };
 
+pub(crate) mod clients;
 mod constants;
 pub(crate) mod datatypes;
 pub(crate) mod errors;
@@ -13,8 +15,6 @@ pub(crate) mod observability;
 pub(crate) mod operations;
 pub(crate) mod types;
 pub(crate) mod utils;
-
-pub trait IntoString: Into<String> + Debug {}
 
 /// A trait for types that can be converted into a String and debugged.
 ///
@@ -24,7 +24,9 @@ pub trait IntoString: Into<String> + Debug {}
 /// # Note
 ///
 /// This trait is automatically implemented for all types that satisfy
-/// both `Into<String>` and `Debug`.
+/// both `Into<String>` and `Debug`
+pub trait IntoString: Into<String> + Debug {}
+
 impl<T: Into<String> + Debug> IntoString for T {}
 
 #[cfg(feature = "tracing")]


### PR DESCRIPTION
🧬feat(client): add Client API for create/subscribe, DatatypeSet, and client-scoped tracing
📜doc(client): add documents for public client structs, methods, and enums related to the client

- Add clients::{Client, DatatypeManager} to create/subscribe datatypes (Counter for now).
- Introduce DatatypeSet to wrap datatypes and expose common type/state access.
- Add ClientError::CannotSubscribeOrCreateDatatype and cover with error macro tests.
- Wire ClientInfo into TransactionalDatatype and add collection/alias/cuid tracing attributes.
- Update Counter construction and docs/tests to go through Client; re-export Client, ClientError, DatatypeSet.
- BREAKING: Counter::new made pub(crate) and tied to ClientInfo; use Client::{create_counter, subscribe_counter, subscribe_or_create_counter}.
- fix minor bug for transaction