### PR TITLE
🧬feat(datatype): add DatatypeBuilder with rollback options

### DIFF
--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -49,6 +49,7 @@ jobs:
           SYNCYAM_RS_OTEL_ENABLED=false cargo tarpaulin \
             --all-features \
             --engine llvm \
+            --fail-under 90 \
             --out Lcov \
             --out html \
             --out xml \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "ubyte",
 ]
 
 [[package]]
@@ -1714,6 +1715,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4.41"
 thiserror = "^2.0.16"
 opentelemetry = { version = "^0.30.0" }
 tracing-opentelemetry = { version = "^0.31.0" }
-
+ubyte = "^0.10.4"
 
 [dev-dependencies]
 rstest = "^0.26.1"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 
 .PHONY: tarpaulin
 tarpaulin:
-	SYNCYAM_RS_OTEL_ENABLED=true cargo tarpaulin -o html -o xml -o Lcov --tests --lib --all-features --engine Llvm --output-dir ./coverage
+	SYNCYAM_RS_OTEL_ENABLED=true cargo tarpaulin -o html -o xml -o Lcov --tests --all-features --engine Llvm --fail-under 90 --output-dir ./coverage
 	open coverage/tarpaulin-report.html
 
 .PHONY: update-coverage-badge

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 
 .PHONY: tarpaulin
 tarpaulin:
-	SYNCYAM_RS_OTEL_ENABLED=true cargo tarpaulin -o html -o xml -o Lcov --all-features --engine llvm --output-dir ./coverage
+	SYNCYAM_RS_OTEL_ENABLED=true cargo tarpaulin -o html -o xml -o Lcov --tests --lib --all-features --engine Llvm --output-dir ./coverage
 	open coverage/tarpaulin-report.html
 
 .PHONY: update-coverage-badge

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        # Require at least 90% overall project coverage
+        target: 90%
+        # Allow a small fluctuation before failing the check
+        threshold: 1%
+    patch:
+      default:
+        # Also require new/changed code to meet 90%
+        target: 90%
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/src/datatypes/builder.rs
+++ b/src/datatypes/builder.rs
@@ -1,0 +1,210 @@
+use crate::{
+    Client, ClientError, Counter, DataType, DatatypeSet, DatatypeState,
+    datatypes::option::DatatypeOption, defaults, errors::err,
+};
+
+/// A builder for constructing SyncYam datatypes with configurable options.
+///
+/// `DatatypeBuilder` is obtained from a [`Client`] via one of:
+/// - [`Client::subscribe_datatype`] — subscribe to an existing datatype by key
+/// - [`Client::create_datatype`] — create a new datatype by key
+/// - [`Client::subscribe_or_create_datatype`] — subscribe if exists, otherwise create
+///
+/// Once created, you can tune rollback-related options and then finalize
+/// construction by calling a concrete builder, such as [`DatatypeBuilder::build_counter`].
+///
+/// Rollback-related options control how much history/memory is kept to support
+/// transactional rollbacks:
+/// - max number of rollback transactions
+/// - max size of rollback memory (bytes)
+///
+/// The provided values are clamped to an allowed range. If a value is smaller
+/// than the minimum, the minimum is used; if larger than the maximum, the
+/// maximum is used.
+///
+/// # Examples
+/// Create a counter with custom rollback limits:
+/// ```
+/// use syncyam::Client;
+/// let client = Client::builder("docs-collection", "docs-app").build();
+/// let counter = client
+///     .create_datatype("docs-counter")
+///     .with_max_num_of_rollback_transactions(1_000)
+///     .with_max_size_of_rollback_memory(1_000_000)
+///     .build_counter()
+///     .unwrap();
+/// assert_eq!(counter.get_value(), 0);
+/// ```
+///
+/// The builder preserves the intended lifecycle state based on how it was
+/// obtained from [`Client`]. For example:
+/// ```
+/// use syncyam::{Client, DatatypeState};
+/// let client = Client::builder("docs-collection", "docs-app").build();
+/// assert_eq!(
+///     client.subscribe_datatype("k").build_counter().unwrap().get_state(),
+///     DatatypeState::DueToSubscribe
+/// );
+/// assert_eq!(
+///     client.create_datatype("k").build_counter().unwrap().get_state(),
+///     DatatypeState::DueToCreate
+/// );
+/// assert_eq!(
+///     client
+///         .subscribe_or_create_datatype("k")
+///         .build_counter()
+///         .unwrap()
+///         .get_state(),
+///     DatatypeState::DueToSubscribeOrCreate
+/// );
+/// ```
+pub struct DatatypeBuilder<'c> {
+    client: &'c Client,
+    key: String,
+    state: DatatypeState,
+    max_num_of_rollback_transactions: u32,
+    max_size_of_rollback_memory: u64,
+}
+
+impl<'c> DatatypeBuilder<'c> {
+    /// Creates a new builder. This is used internally by [`Client`].
+    pub(crate) fn new(client: &'c Client, key: String, state: DatatypeState) -> Self {
+        Self {
+            client,
+            key,
+            state,
+            max_num_of_rollback_transactions: defaults::DEFAULT_MAX_NUM_OF_ROLLBACK_TRANSACTIONS,
+            max_size_of_rollback_memory: defaults::DEFAULT_MAX_SIZE_OF_ROLLBACK_MEMORY,
+        }
+    }
+
+    /// Sets the maximum number of rollback transactions to retain.
+    ///
+    /// The value is clamped to a valid range. If `max` is smaller than the
+    /// lower bound, the lower bound is used. If it exceeds the upper bound,
+    /// the upper bound is used.
+    ///
+    /// Returns the builder for method chaining.
+    pub fn with_max_num_of_rollback_transactions(mut self, max: u32) -> Self {
+        self.max_num_of_rollback_transactions = max.clamp(
+            defaults::LOWER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS,
+            defaults::UPPER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS,
+        );
+        self
+    }
+
+    /// Sets the maximum size of rollback memory (in bytes).
+    ///
+    /// The value is clamped to a valid range. If `max` is smaller than the
+    /// lower bound, the lower bound is used. If it exceeds the upper bound,
+    /// the upper bound is used.
+    ///
+    /// Returns the builder for method chaining.
+    pub fn with_max_size_of_rollback_memory(mut self, max: u64) -> Self {
+        self.max_size_of_rollback_memory = max.clamp(
+            defaults::LOWER_MAX_SIZE_OF_ROLLBACK_MEMORY,
+            defaults::UPPER_MAX_SIZE_OF_ROLLBACK_MEMORY,
+        );
+        self
+    }
+
+    /// Finalizes the builder and constructs a [`Counter`].
+    ///
+    /// Applies the configured rollback options and uses the builder's
+    /// lifecycle state (subscribe/create/subscribe-or-create) to return
+    /// a ready-to-use counter.
+    ///
+    /// # Errors
+    /// Returns [`ClientError`] if the underlying creation/subscription fails.
+    ///
+    /// # Examples
+    /// ```
+    /// use syncyam::Client;
+    /// let client = Client::builder("col", "alias").build();
+    /// let counter = client
+    ///     .create_datatype("counter-1")
+    ///     .with_max_num_of_rollback_transactions(500)
+    ///     .with_max_size_of_rollback_memory(256 * 1024)
+    ///     .build_counter()
+    ///     .unwrap();
+    /// assert_eq!(counter.get_value(), 0);
+    /// ```
+    pub fn build_counter(self) -> Result<Counter, ClientError> {
+        let option = DatatypeOption::new(
+            self.max_num_of_rollback_transactions,
+            self.max_size_of_rollback_memory,
+        );
+        match self.client.do_subscribe_or_create_datatype(
+            self.key,
+            DataType::Counter,
+            self.state,
+            option,
+        ) {
+            Ok(ds) => match ds {
+                DatatypeSet::Counter(counter) => Ok(counter),
+            },
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_datatype_builder {
+    use crate::{Client, defaults};
+
+    #[test]
+    fn can_use_rollback_related_datatype_builder() {
+        let client = Client::builder(module_path!(), module_path!()).build();
+        let mut builder = client.subscribe_datatype(module_path!());
+        assert_eq!(
+            defaults::DEFAULT_MAX_SIZE_OF_ROLLBACK_MEMORY,
+            builder.max_size_of_rollback_memory
+        );
+        assert_eq!(
+            defaults::DEFAULT_MAX_NUM_OF_ROLLBACK_TRANSACTIONS,
+            builder.max_num_of_rollback_transactions
+        );
+
+        builder = builder
+            .with_max_size_of_rollback_memory(0)
+            .with_max_num_of_rollback_transactions(0);
+        assert_eq!(
+            defaults::LOWER_MAX_SIZE_OF_ROLLBACK_MEMORY,
+            builder.max_size_of_rollback_memory
+        );
+        assert_eq!(
+            defaults::LOWER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS,
+            builder.max_num_of_rollback_transactions
+        );
+
+        builder = builder
+            .with_max_size_of_rollback_memory(defaults::UPPER_MAX_SIZE_OF_ROLLBACK_MEMORY + 1)
+            .with_max_num_of_rollback_transactions(
+                defaults::UPPER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS + 1,
+            );
+        assert_eq!(
+            defaults::UPPER_MAX_SIZE_OF_ROLLBACK_MEMORY,
+            builder.max_size_of_rollback_memory
+        );
+        assert_eq!(
+            defaults::UPPER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS,
+            builder.max_num_of_rollback_transactions
+        );
+
+        builder = builder
+            .with_max_size_of_rollback_memory(defaults::LOWER_MAX_SIZE_OF_ROLLBACK_MEMORY + 1)
+            .with_max_num_of_rollback_transactions(
+                defaults::LOWER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS + 1,
+            );
+        assert_eq!(
+            defaults::LOWER_MAX_SIZE_OF_ROLLBACK_MEMORY + 1,
+            builder.max_size_of_rollback_memory
+        );
+        assert_eq!(
+            defaults::LOWER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS + 1,
+            builder.max_num_of_rollback_transactions
+        );
+
+        let _counter = builder.build_counter().unwrap();
+    }
+}

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -8,6 +8,7 @@ use crate::{
         crdts::Crdt,
         datatype::DatatypeBlanket,
         datatype_instrument,
+        option::DatatypeOption,
         transactional::{TransactionContext, TransactionalDatatype},
     },
     operations::Operation,
@@ -21,14 +22,19 @@ pub struct Counter {
 }
 
 impl Counter {
-    // TODO: this should be pub (crate)
-    pub(crate) fn new(key: String, state: DatatypeState, client_info: Arc<ClientInfo>) -> Self {
+    pub(crate) fn new(
+        key: String,
+        state: DatatypeState,
+        client_info: Arc<ClientInfo>,
+        option: DatatypeOption,
+    ) -> Self {
         Counter {
             datatype: Arc::new(TransactionalDatatype::new(
                 &key,
                 DataType::Counter,
                 state,
                 client_info,
+                option,
             )),
             tx_ctx: Default::default(),
         }
@@ -52,8 +58,8 @@ impl Counter {
     ///
     /// ```
     /// # use syncyam::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("test-collection", "test-client").build().unwrap();
-    /// let counter = client.create_counter("test-counter".to_string()).unwrap();
+    /// let client = Client::builder("test-collection", "test-client").build();
+    /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     /// assert_eq!(counter.increase_by(5), 5);
     /// assert_eq!(counter.increase_by(-2), 3);
     /// ```
@@ -80,8 +86,8 @@ impl Counter {
     ///
     /// ```
     /// # use syncyam::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("test-collection", "test-client").build().unwrap();
-    /// let counter = client.create_counter("test-counter".to_string()).unwrap();
+    /// let client = Client::builder("test-collection", "test-client").build();
+    /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     /// assert_eq!(counter.increase(), 1);
     /// assert_eq!(counter.increase(), 2);
     /// ```
@@ -99,8 +105,8 @@ impl Counter {
     ///
     /// ```
     /// # use syncyam::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("test-collection", "test-client").build().unwrap();
-    /// let counter = client.create_counter("test-counter".to_string()).unwrap();
+    /// let client = Client::builder("test-collection", "test-client").build();
+    /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     /// assert_eq!(counter.get_value(), 0);
     /// counter.increase();
     /// assert_eq!(counter.get_value(), 1);
@@ -130,8 +136,8 @@ impl Counter {
     ///
     /// ```
     /// # use syncyam::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("test-collection", "test-client").build().unwrap();
-    /// let counter = client.create_counter("test-counter".to_string()).unwrap();
+    /// let client = Client::builder("test-collection", "test-client").build();
+    /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     ///
     /// // Successful transaction
     /// let result = counter.transaction("batch-update", |c| {
@@ -201,6 +207,7 @@ mod tests_counter {
             module_path!().to_owned(),
             Default::default(),
             Default::default(),
+            Default::default(),
         );
         assert_eq!(counter.get_type(), DataType::Counter);
         assert_eq!(counter.get_key(), module_path!().to_string());
@@ -214,6 +221,7 @@ mod tests_counter {
             module_path!().to_owned(),
             Default::default(),
             Default::default(),
+            Default::default(),
         );
         assert_eq!(1, counter.increase());
         assert_eq!(11, counter.increase_by(10));
@@ -225,6 +233,7 @@ mod tests_counter {
     fn can_use_transaction() {
         let counter = Counter::new(
             module_path!().to_owned(),
+            Default::default(),
             Default::default(),
             Default::default(),
         );
@@ -250,6 +259,7 @@ mod tests_counter {
     async fn can_run_transactions_concurrently() {
         let counter = Counter::new(
             module_path!().to_owned(),
+            Default::default(),
             Default::default(),
             Default::default(),
         );

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -1,12 +1,12 @@
 use crate::{DataType, DatatypeState, datatypes::transactional::TransactionalDatatype};
 
 /// The `Datatype` trait defines the common interface for all
-/// conflict-free datatypes (e.g., Counter, Register).
+/// conflict-free datatypes (e.g., Counter, Register, Document).
 ///
 /// Each datatype exposes:
-/// - a **key**: a unique identifier used to distinguish instances,
+/// - a **key**: a unique identifier used to distinguish instances in a collection,
 /// - a **type**: an enum variant of [`DataType`] describing the kind of datatype,
-/// - a **state**: a [`DatatypeState`] indicating the current lifecycle/status.
+/// - a **state**: a [`DatatypeState`] indicating the current lifecycle/state of this datatype.
 ///
 ///
 /// # Example
@@ -14,15 +14,18 @@ use crate::{DataType, DatatypeState, datatypes::transactional::TransactionalData
 /// use syncyam::Client;
 /// use syncyam::{Counter, Datatype};
 /// use syncyam::{DatatypeState, DataType};
-/// let client = Client::builder("test-collection", "test-client").build().unwrap();
-/// let counter = client.create_counter("test-counter".to_string()).unwrap();
+/// let client = Client::builder("test-collection", "test-client").build();
+/// let counter = client.create_datatype("test-counter".to_string()).build_counter().unwrap();
 /// assert_eq!(counter.get_key(), "test-counter");
 /// assert_eq!(counter.get_type(), DataType::Counter);
 /// assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
 /// ```
 pub trait Datatype {
+    /// returns a unique identifier used to distinguish instances in a collection.
     fn get_key(&self) -> &str;
+    /// returns an enum variant of [`DataType`] describing the kind of this datatype.
     fn get_type(&self) -> DataType;
+    /// returns a [`DatatypeState`] indicating the current lifecycle/status of this datatype.
     fn get_state(&self) -> DatatypeState;
 }
 
@@ -60,6 +63,7 @@ mod tests_datatype_trait {
         let data = TransactionalDatatype::new(
             key,
             DataType::Counter,
+            Default::default(),
             Default::default(),
             Default::default(),
         );

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -1,9 +1,11 @@
+pub mod builder;
 pub mod common;
 #[allow(dead_code)]
 pub mod counter;
 mod crdts;
 pub mod datatype;
 mod mutable;
+pub mod option;
 mod rollback;
 mod transactional;
 
@@ -27,7 +29,10 @@ use std::sync::Arc;
 
 pub(crate) use datatype_instrument;
 
-use crate::{Counter, DataType, Datatype, DatatypeState, clients::client::ClientInfo};
+use crate::{
+    Counter, DataType, Datatype, DatatypeState, clients::client::ClientInfo,
+    datatypes::option::DatatypeOption,
+};
 
 /// A typed wrapper for concrete datatypes managed by the client.
 ///
@@ -63,10 +68,11 @@ impl DatatypeSet {
         key: &str,
         state: DatatypeState,
         client_info: Arc<ClientInfo>,
+        option: DatatypeOption,
     ) -> Self {
         match r#type {
             DataType::Counter => {
-                DatatypeSet::Counter(Counter::new(key.to_owned(), state, client_info))
+                DatatypeSet::Counter(Counter::new(key.to_owned(), state, client_info, option))
             }
             _ => {
                 todo!()
@@ -97,6 +103,7 @@ mod tests_datatype_set {
             DataType::Counter,
             "k1",
             DatatypeState::DueToCreate,
+            Default::default(),
             Default::default(),
         );
         let ds2 = ds1.clone();

--- a/src/datatypes/option.rs
+++ b/src/datatypes/option.rs
@@ -1,0 +1,24 @@
+use crate::defaults;
+
+pub struct DatatypeOption {
+    pub max_num_of_rollback_transactions: u32,
+    pub max_size_of_rollback_memory: u64,
+}
+
+impl DatatypeOption {
+    pub fn new(max_num_of_rollback_transactions: u32, max_size_of_rollback_memory: u64) -> Self {
+        Self {
+            max_num_of_rollback_transactions,
+            max_size_of_rollback_memory,
+        }
+    }
+}
+
+impl Default for DatatypeOption {
+    fn default() -> Self {
+        Self::new(
+            defaults::DEFAULT_MAX_NUM_OF_ROLLBACK_TRANSACTIONS,
+            defaults::DEFAULT_MAX_SIZE_OF_ROLLBACK_MEMORY,
+        )
+    }
+}

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -8,7 +8,9 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::{
     DataType, DatatypeState, IntoString,
     clients::client::ClientInfo,
-    datatypes::{common::ReturnType, datatype::Datatype, mutable::MutableDatatype},
+    datatypes::{
+        common::ReturnType, datatype::Datatype, mutable::MutableDatatype, option::DatatypeOption,
+    },
     errors::datatypes::DatatypeError,
     operations::Operation,
     types::uid::Duid,
@@ -74,6 +76,7 @@ pub struct Attributes {
     pub r#type: DataType,
     pub duid: Duid,
     pub client_info: Arc<ClientInfo>,
+    pub option: DatatypeOption,
 }
 
 pub struct TransactionalDatatype {
@@ -104,12 +107,14 @@ impl TransactionalDatatype {
         r#type: DataType,
         state: DatatypeState,
         client_info: Arc<ClientInfo>,
+        option: DatatypeOption,
     ) -> Self {
         let attr = Attributes {
             key: key.to_owned(),
             r#type,
             duid: Duid::new(),
             client_info,
+            option,
         };
         let transactional = Self {
             attr,
@@ -283,6 +288,7 @@ mod tests_transactional {
             DataType::Counter,
             Default::default(),
             Default::default(),
+            Default::default(),
         ));
         {
             let mutable = tx_dt.mutable.write();
@@ -319,6 +325,7 @@ mod tests_transactional {
             DataType::Counter,
             Default::default(),
             Default::default(),
+            Default::default(),
         ));
         let parent_span = Span::current();
 
@@ -352,6 +359,7 @@ mod tests_transactional {
         let tx_dt = Arc::new(TransactionalDatatype::new(
             module_path!(),
             DataType::Counter,
+            Default::default(),
             Default::default(),
             Default::default(),
         ));

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -1,0 +1,7 @@
+pub(crate) const DEFAULT_MAX_NUM_OF_ROLLBACK_TRANSACTIONS: u32 = 10_000;
+pub(crate) const LOWER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS: u32 = 5;
+pub(crate) const UPPER_MAX_NUM_OF_ROLLBACK_TRANSACTIONS: u32 = 1_000_000;
+
+pub(crate) const DEFAULT_MAX_SIZE_OF_ROLLBACK_MEMORY: u64 = 10 * ubyte::ByteUnit::MiB.as_u64();
+pub(crate) const LOWER_MAX_SIZE_OF_ROLLBACK_MEMORY: u64 = ubyte::ByteUnit::MiB.as_u64();
+pub(crate) const UPPER_MAX_SIZE_OF_ROLLBACK_MEMORY: u64 = ubyte::ByteUnit::GiB.as_u64();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 pub use crate::{
     clients::client::Client,
-    datatypes::{DatatypeSet, counter::Counter, datatype::Datatype},
+    datatypes::{DatatypeSet, builder::DatatypeBuilder, counter::Counter, datatype::Datatype},
     errors::{clients::ClientError, datatypes::DatatypeError},
     types::datatype::{DataType, DatatypeState},
 };
@@ -10,6 +10,7 @@ pub use crate::{
 pub(crate) mod clients;
 mod constants;
 pub(crate) mod datatypes;
+pub(crate) mod defaults;
 pub(crate) mod errors;
 pub(crate) mod observability;
 pub(crate) mod operations;

--- a/tests/datatype_builder.rs
+++ b/tests/datatype_builder.rs
@@ -1,0 +1,19 @@
+mod tests_datatype_builder {
+    use syncyam::{Client, DataType, Datatype, DatatypeState};
+
+    #[test]
+    fn can_build_counter() {
+        let client = Client::builder(module_path!(), module_path!()).build();
+        let counter = client
+            .create_datatype(module_path!())
+            .with_max_num_of_rollback_transactions(100000)
+            .with_max_size_of_rollback_memory(10_000_000)
+            .build_counter()
+            .unwrap();
+        counter.increase_by(42);
+        assert_eq!(module_path!(), counter.get_key());
+        assert_eq!(DataType::Counter, counter.get_type());
+        assert_eq!(DatatypeState::DueToCreate, counter.get_state());
+        assert_eq!(counter.get_value(), 42);
+    }
+}


### PR DESCRIPTION
fixed #35 

- Introduce DatatypeBuilder with clamped rollback limits (transactions, memory) 
- Add Client builder APIs: subscribe/create/subscribe-or-create 
- Add DatatypeOption and defaults; thread options into TransactionalDatatype/Counter 
- Add DatatypeSet wrapper; validate type/state in DatatypeManager Add tests and documentation